### PR TITLE
Adding link to logo file in DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -139,6 +139,14 @@
         }
       ]
     },
+	{
+      "category": "logo",
+      "values": [
+        {
+          "value": "logo.png"
+        }
+      ]
+    },
     {
       "category": "REB_statement",
       "values": [


### PR DESCRIPTION
This PR adds a `logo` entry in `extraProperties` in the DATS.json file.